### PR TITLE
Added tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .iOS(.v13),
+        .tvOS(.v13),
     ],
     products: [
         .library(name: "SotoCognitoAuthenticationKit", targets: ["SotoCognitoAuthenticationKit"]),
@@ -30,7 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/soto-project/soto.git", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/vapor/jwt-kit.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/vapor/jwt-kit.git", .upToNextMajor(from: "4.2.6")),
         // for SRP
         .package(url: "https://github.com/adam-fowler/big-num.git", .upToNextMajor(from: "2.0.0")),
     ],


### PR DESCRIPTION
Based on changes made in `jwt-kit` dependency (https://github.com/vapor/jwt-kit/pull/63), the repo can support tvOS.