### PR TITLE
Ensure TIMESTAMP presents date-time in English locale format for SRP authentication

### DIFF
--- a/Sources/SotoCognitoAuthenticationSRP/Authenticatable+SRP+async.swift
+++ b/Sources/SotoCognitoAuthenticationSRP/Authenticatable+SRP+async.swift
@@ -84,7 +84,7 @@ public extension CognitoAuthenticatable {
         dateFormatter.dateFormat = "EEE MMM d HH:mm:ss 'UTC' yyyy"
         dateFormatter.timeZone = TimeZone(identifier: "UTC")
         // cognito expects the dateformat to be in English
-        dateFormatter.locale = Locale(identifier: "en")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         let timestamp = dateFormatter.string(from: Date())
 
         // construct claim

--- a/Sources/SotoCognitoAuthenticationSRP/Authenticatable+SRP+async.swift
+++ b/Sources/SotoCognitoAuthenticationSRP/Authenticatable+SRP+async.swift
@@ -83,6 +83,8 @@ public extension CognitoAuthenticatable {
         // cognito expects the dateformat to have the timezone as UTC
         dateFormatter.dateFormat = "EEE MMM d HH:mm:ss 'UTC' yyyy"
         dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        // cognito expects the dateformat to be in English
+        dateFormatter.locale = Locale(identifier: "en")
         let timestamp = dateFormatter.string(from: Date())
 
         // construct claim


### PR DESCRIPTION
It is not possible to authenticate when your iPhone's locale is not English. The error is thrown: 

> InvalidParameterException: TIMESTAMP format should be EEE MMM d HH:mm:ss z yyyy in english. 

With my fix, the TIMESTAMP will present date-time in English locale format which will avoid the reported issue.